### PR TITLE
feat: support custom virtual environment paths

### DIFF
--- a/src/project_managers.rs
+++ b/src/project_managers.rs
@@ -102,6 +102,7 @@ impl ProjectCreator {
                     "./src/main.py"
                 }
                 .to_string(),
+                self.project.venv.clone(),
             ),
             HashMap::new(),
             HashMap::new(),
@@ -145,7 +146,12 @@ impl ProjectCreator {
         }
 
         if !self.project.no_venv {
-            if let Err(e) = setup_venv(self.get_path_with("venv")) {
+            let venv_path = self
+                .project
+                .venv
+                .clone()
+                .unwrap_or_else(|| "venv".to_string());
+            if let Err(e) = setup_venv(self.get_path_with(&venv_path)) {
                 eprint(format!("Failed to setup venv: {}", e));
                 return;
             }
@@ -178,6 +184,9 @@ pub struct ProjectConf {
     /// Set Project Description
     #[clap(short = 'd', long = "description", default_value = "")]
     description: String,
+    /// Set Virtual Environment Name
+    #[clap(long = "venv")]
+    venv: Option<String>,
     /// Enable Git
     #[clap(short = 'g', long = "git", takes_value = false)]
     git: bool,
@@ -215,10 +224,12 @@ impl AddPackage {
             }
         };
 
+        let venv_root = conf.project.venv.as_deref().unwrap_or("venv");
+
         for pkg_name in self.pkg_names.iter() {
             let (vname, ver) = parse_version(pkg_name);
 
-            match install_package(pkg_name) {
+            match install_package(pkg_name, venv_root) {
                 Ok(_) => {
                     let version = match ver {
                         Some(v) => v,
@@ -255,13 +266,13 @@ pub struct RemovePackage {
 }
 
 impl RemovePackage {
-    fn uninstall_package(&self, pkg: &str) -> Result<(), String> {
-        if !check_venv_dir_exists() {
+    fn uninstall_package(&self, pkg: &str, venv_root: &str) -> Result<(), String> {
+        if !check_venv_dir_exists(venv_root) {
             return Err("Virtual Environment Not Found".to_string());
         }
 
         iprint(format!("Uninstalling {}", pkg));
-        let output = Command::new(get_venv_pip_path())
+        let output = Command::new(get_venv_pip_path(venv_root))
             .arg("uninstall")
             .arg("-y")
             .arg(pkg)
@@ -294,13 +305,15 @@ impl RemovePackage {
             }
         };
 
+        let venv_root = conf.project.venv.clone().unwrap_or_else(|| "venv".to_string());
+
         for pkg_name in self.pkg_names.iter() {
             if !conf.packages.contains_key(pkg_name) {
                 eprint(format!("Package '{}' does not exist", pkg_name));
                 continue;
             }
 
-            match self.uninstall_package(pkg_name) {
+            match self.uninstall_package(pkg_name, &venv_root) {
                 Ok(_) => {
                     conf.packages.remove(pkg_name);
                     match conf.write_to_file(config_file) {
@@ -352,6 +365,8 @@ impl RunScript {
             }
         };
 
+        let venv_root = conf.project.venv.as_deref().unwrap_or("venv");
+
         let mut cmd = if cfg!(target_os = "windows") {
             let mut c = Command::new("cmd");
             c.arg("/C");
@@ -365,7 +380,7 @@ impl RunScript {
             return;
         };
 
-        cmd.env("PATH", get_venv_bin_dir());
+        cmd.env("PATH", get_venv_bin_dir(venv_root));
         cmd.arg(cmd_str);
 
         match cmd.spawn() {
@@ -390,10 +405,26 @@ pub struct Installer {
 
 impl Installer {
     fn install_from_req(&self) {
-        if !check_venv_dir_exists() {
-            wprint("Could not find venv directory".to_owned());
+        let config_file = get_project_config_file();
+        if !Path::new(config_file).exists() {
+            eprint(format!("Could not find {}", config_file));
+            return;
+        }
+
+        let mut conf = match Config::load_from_file(config_file) {
+            Ok(conf) => conf,
+            Err(e) => {
+                eprint(e.to_string());
+                return;
+            }
+        };
+
+        let venv_root = conf.project.venv.clone().unwrap_or_else(|| "venv".to_string());
+
+        if !check_venv_dir_exists(&venv_root) {
+            wprint(format!("Could not find '{}' directory", venv_root));
             if ask_if_create_venv() {
-                if let Err(e) = setup_venv("./venv".to_owned()) {
+                if let Err(e) = setup_venv(format!("./{}", venv_root)) {
                     eprint(format!("Failed to setup venv: {}", e));
                     return;
                 }
@@ -411,12 +442,6 @@ impl Installer {
             }
         };
 
-        let config_file = get_project_config_file();
-        if !Path::new(config_file).exists() {
-            eprint(format!("Could not find {}", config_file));
-            return;
-        }
-
         let pkg_names: Vec<&str> = req_file
             .lines()
             .filter(|line| !line.trim().is_empty() && !line.starts_with('#'))
@@ -427,18 +452,10 @@ impl Installer {
             return;
         }
 
-        let mut conf = match Config::load_from_file(config_file) {
-            Ok(conf) => conf,
-            Err(e) => {
-                eprint(e.to_string());
-                return;
-            }
-        };
-
         for pkg_name in pkg_names.iter() {
             let (vname, ver) = parse_version(pkg_name);
 
-            match install_package(pkg_name) {
+            match install_package(pkg_name, &venv_root) {
                 Ok(_) => {
                     let version = match ver {
                         Some(v) => v,
@@ -492,10 +509,12 @@ impl Installer {
             return;
         }
 
-        if !check_venv_dir_exists() {
-            wprint("Could not find venv directory".to_owned());
+        let venv_root = conf.project.venv.as_deref().unwrap_or("venv");
+
+        if !check_venv_dir_exists(venv_root) {
+            wprint(format!("Could not find '{}' directory", venv_root));
             if ask_if_create_venv() {
-                if let Err(e) = setup_venv("./venv".to_owned()) {
+                if let Err(e) = setup_venv(format!("./{}", venv_root)) {
                     eprint(format!("Failed to setup venv: {}", e));
                     return;
                 }
@@ -507,7 +526,7 @@ impl Installer {
 
         for (name, version) in conf.packages.iter() {
             let package_spec = format!("{}=={}", name, version);
-            match install_package(&package_spec) {
+            match install_package(&package_spec, venv_root) {
                 Ok(_) => iprint(format!("Package '{}' installed", name)),
                 Err(e) => eprint(format!("Failed to install '{}': {}", name, e)),
             }
@@ -546,6 +565,8 @@ impl BuildProject {
 
         iprint(format!("Building project: {}", conf.project.name));
 
+        let venv_root = conf.project.venv.as_deref().unwrap_or("venv");
+
         let mut cmd = if cfg!(target_os = "windows") {
             let mut c = Command::new("cmd");
             c.arg("/C");
@@ -559,7 +580,7 @@ impl BuildProject {
             return;
         };
 
-        cmd.env("PATH", get_venv_bin_dir());
+        cmd.env("PATH", get_venv_bin_dir(venv_root));
         cmd.arg(build_script);
 
         match cmd.spawn() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,15 +8,23 @@ pub struct Project {
     pub version: String,
     pub description: String,
     pub main_script: String,
+    pub venv: Option<String>,
 }
 
 impl Project {
-    pub fn new(name: String, version: String, description: String, main_script: String) -> Project {
+    pub fn new(
+        name: String,
+        version: String,
+        description: String,
+        main_script: String,
+        venv: Option<String>,
+    ) -> Project {
         Project {
             name,
             version,
             description,
             main_script,
+            venv,
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,16 +26,16 @@ const VENV_BIN_DIR: &str = "Scripts";
 #[cfg(not(target_os = "windows"))]
 const VENV_BIN_DIR: &str = "bin";
 
-pub fn get_venv_python_path() -> String {
-    format!("./venv/{}/{}", VENV_BIN_DIR, PYTHON_EXE)
+pub fn get_venv_python_path(venv_root: &str) -> String {
+    format!("./{}/{}/{}", venv_root, VENV_BIN_DIR, PYTHON_EXE)
 }
 
-pub fn get_venv_pip_path() -> String {
-    format!("./venv/{}/{}", VENV_BIN_DIR, PIP_EXE)
+pub fn get_venv_pip_path(venv_root: &str) -> String {
+    format!("./{}/{}/{}", venv_root, VENV_BIN_DIR, PIP_EXE)
 }
 
-pub fn get_venv_bin_dir() -> String {
-    format!("./venv/{}/", VENV_BIN_DIR)
+pub fn get_venv_bin_dir(venv_root: &str) -> String {
+    format!("./{}/{}/", venv_root, VENV_BIN_DIR)
 }
 
 pub fn get_project_config_file() -> &'static str {
@@ -71,12 +71,12 @@ pub fn project_exists(name: &String, is_init: bool) -> bool {
         Path::new(get_project_config_file()).exists()
     } else {
         Path::new(name).exists()
-            && Path::new(&format!("{}/{}", name, get_project_config_file())).exists()
+        && Path::new(&format!("{}/{}", name, get_project_config_file())).exists()
     }
 }
 
-pub fn check_venv_dir_exists() -> bool {
-    Path::new(&get_venv_bin_dir()).exists()
+pub fn check_venv_dir_exists(venv_root: &str) -> bool {
+    Path::new(&get_venv_bin_dir(venv_root)).exists()
 }
 
 pub fn get_pkg_version(pkg: &str) -> Result<String, String> {
@@ -154,15 +154,15 @@ fn validate_package_name(pkg: &str) -> Result<(), String> {
     Ok(())
 }
 
-pub fn install_package(pkg: &str) -> Result<(), String> {
-    if !check_venv_dir_exists() {
+pub fn install_package(pkg: &str, venv_root: &str) -> Result<(), String> {
+    if !check_venv_dir_exists(venv_root) {
         return Err("Virtual Environment Not Found".to_string());
     }
 
     validate_package_name(pkg)?;
 
     iprint(format!("Installing '{}'", pkg));
-    let output = Command::new(get_venv_pip_path())
+    let output = Command::new(get_venv_pip_path(venv_root))
         .arg("install")
         .arg(pkg)
         .output()


### PR DESCRIPTION

#30


# Support Custom Virtual Environment Paths

## Description
This PR addresses the issue where the virtual environment path was hardcoded to [./venv](cci:1://file:///d:/OSCG/pppm/ppmm/src/utils.rs:97:0-113:1). Users can now configure a custom virtual environment name (e.g., `.venv`) in `project.toml`.

## Changes
- **Configuration**: Added an optional [venv](cci:1://file:///d:/OSCG/pppm/ppmm/src/utils.rs:97:0-113:1) field to the [Project](cci:2://file:///d:/OSCG/pppm/ppmm/src/settings.rs:5:0-11:1) struct in [src/settings.rs](cci:7://file:///d:/OSCG/pppm/ppmm/src/settings.rs:0:0-0:0) to support custom virtual environment paths.
- **Utils**: Refactored [src/utils.rs](cci:7://file:///d:/OSCG/pppm/ppmm/src/utils.rs:0:0-0:0) functions ([get_venv_python_path](cci:1://file:///d:/OSCG/pppm/ppmm/src/utils.rs:28:0-30:1), [install_package](cci:1://file:///d:/OSCG/pppm/ppmm/src/utils.rs:156:0-179:1), etc.) to accept a `venv_root` argument, removing hardcoded paths.
- **Core Logic**: Updated [src/project_managers.rs](cci:7://file:///d:/OSCG/pppm/ppmm/src/project_managers.rs:0:0-0:0) and [src/ppm_functions.rs](cci:7://file:///d:/OSCG/pppm/ppmm/src/ppm_functions.rs:0:0-0:0) to retrieve the [venv](cci:1://file:///d:/OSCG/pppm/ppmm/src/utils.rs:97:0-113:1) path from the configuration and pass it throughout the application.
- **CLI**: `pppm new` and `pppm init` now support a `--venv` flag.

## How to Test
1. Create a new project or update an existing `project.toml`:
   ```toml
   [project]
   name = "test-project"
   version = "0.1.0"
   venv = ".venv"