### PR TITLE
Fix panic on non-interactive stdin/stdout operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = { version = "0.13", features = ["json", "blocking"] }
 serde_json = "1.0"
 toml = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+is-terminal = "0.4"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.12"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,9 @@
 use colored::*;
-use std::{
-    io::{self, Write},
+    io::{self, Write, IsTerminal},
     path::Path,
     process::Command,
 };
+
 
 // Constants
 const PROJECT_CONFIG_FILE: &str = "project.toml";
@@ -114,6 +114,12 @@ pub fn setup_venv(venv_path: String) -> Result<(), String> {
 }
 
 pub fn ask_if_create_venv() -> bool {
+    // Check if stdin is a terminal
+    if !std::io::stdin().is_terminal() {
+        wprint("Non-interactive environment detected. Defaulting to 'yes' for venv creation.".to_string());
+        return true;
+    }
+
     let mut answer = String::new();
     print!(
         "{}",
@@ -121,11 +127,22 @@ pub fn ask_if_create_venv() -> bool {
             .green()
             .bold()
     );
-    io::stdout().flush().unwrap();
-    io::stdin().read_line(&mut answer).unwrap();
+    
+    // Handle potential flush error safely
+    if let Err(e) = io::stdout().flush() {
+        eprint(format!("Failed to flush stdout: {}", e));
+        return false; // Default safe behavior
+    }
+
+    // Handle read_line error safely
+    if let Err(e) = io::stdin().read_line(&mut answer) {
+        eprint(format!("Failed to read line: {}", e));
+        return false;
+    }
+
     match answer.trim().to_lowercase().as_str() {
-        "y" => true,
-        "n" => false,
+        "y" | "yes" => true,
+        "n" | "no" => false,
         _ => {
             println!("Invalid option");
             ask_if_create_venv()


### PR DESCRIPTION
#45

**Description:** This PR fixes an issue where the application would panic when running in non-interactive environments, such as CI/CD pipelines or background jobs, due to unwrap calls on stdin and stdout.

**Changes:**

Added the is-terminal dependency to reliably detect TTY
Modified the ask_if_create_venv function in src/utils.rs
Replaced unwrap calls with proper error handling
Added a check for non-interactive environments to default to creating the virtual environment
Safely handles errors during flush or read operations by returning false instead of panicking