### PR TITLE
feat: implement lock file support and fix ppm update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ A fast, efficient command-line tool to create, manage, and deploy Python project
 - 🏷️ **Version Control** - Automatic semantic version bumping (major, minor, patch)
 - ✅ **Cross-Platform** - Works seamlessly on Windows, macOS, and Linux
 - ⚡ **Performance** - Optimized Rust implementation with zero runtime dependencies
+- 🔒 **Lock File Support** - Automatic `ppmm.lock` generation for reproducible builds
+
 
 ## Quick Start
 
@@ -589,11 +591,11 @@ cargo watch -x build
 - Package name validation
 - Improved error messages
 - Cross-platform path handling
+- Lock file support (`ppmm.lock`)
 
 ### 🚀 Planned Features
 
 - Dependency resolution
-- Lock file support (like Cargo.lock)
 - Dev dependencies separation
 - Python version management
 - Project templates

--- a/src/ppm_functions.rs
+++ b/src/ppm_functions.rs
@@ -251,6 +251,10 @@ pub fn update_packages() {
             failed_packages.join(", ")
         ));
     }
+
+    if let Err(e) = generate_lock_file(&venv_root) {
+        eprint(format!("Failed to generate lock file: {}", e));
+    }
 }
 
 pub fn list_packages() {


### PR DESCRIPTION


#46
# Feature: Add lock file support for reproducible builds

## Description
This PR implements and verifies lock file support (`ppmm.lock`) to ensure reproducible builds by pinning transitive dependencies.

## Changes
- ✅ Verified existing lock file generation logic in [add](cci:1://file:///d:/OSCG/ppm/ppmm/src/project_managers.rs:213:4-265:5), [remove](cci:1://file:///d:/OSCG/ppm/ppmm/src/project_managers.rs:299:4-343:5), and [install](cci:1://file:///d:/OSCG/ppm/ppmm/src/utils.rs:173:0-196:1) commands.
- 🐛 **Fix:** Updated `ppm update` command to regenerate `ppmm.lock` after updating packages (previously it was missing this step).
- 📝 **Documentation:** Updated [README.md](cci:7://file:///d:/OSCG/ppm/ppmm/README.md:0:0-0:0) to document lock file support and moved it from "Planned" to "Implemented" features.

## How to Test
1. Create a new project: `ppm new test-project`
2. Add a package: `ppm add requests`
3. Verify that `ppmm.lock` is created.
4. Run `ppm update` and verify that `ppmm.lock` is updated/re-generated.
5. Delete [venv](cci:1://file:///d:/OSCG/ppm/ppmm/src/utils.rs:97:0-113:1) and run `ppm install`. Verify installation uses the lock file.