### PR TITLE
feat: add support for updating specific packages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
         Action::Info => ppm_functions::show_project_info(),
         Action::Gen => ppm_functions::gen_requirements(),
         Action::Start => ppm_functions::start_project(),
-        Action::Update => ppm_functions::update_packages(),
+        Action::Update(update) => update.update_package(),
         Action::List => ppm_functions::list_packages(),
     }
 }

--- a/src/ppm_functions.rs
+++ b/src/ppm_functions.rs
@@ -167,7 +167,7 @@ pub fn start_project() {
     }
 }
 
-pub fn update_packages() {
+pub fn update_packages(pkg_names: &Vec<String>) {
     let config_file = get_project_config_file();
     if !Path::new(config_file).exists() {
         eprint(format!("Could not find {}", config_file));
@@ -205,8 +205,32 @@ pub fn update_packages() {
     let mut updates: Vec<(String, String)> = vec![];
     let mut failed_packages: Vec<String> = vec![];
 
-    for (name, _) in conf.packages.iter() {
-        match get_pkg_version(name) {
+    // Filter packages if specific ones are requested
+    let packages_to_check: Vec<String> = if pkg_names.is_empty() {
+        conf.packages.keys().cloned().collect()
+    } else {
+        let mut valid_names = vec![];
+        for name in pkg_names {
+            if conf.packages.contains_key(name) {
+                valid_names.push(name.clone());
+            } else {
+                wprint(format!("Package '{}' not found in project.toml", name));
+            }
+        }
+        valid_names
+    };
+
+    if packages_to_check.is_empty() {
+        if !pkg_names.is_empty() {
+             eprint("No valid packages specified to update".to_owned());
+        } else {
+             eprint("No packages to update".to_owned());
+        }
+        return;
+    }
+
+    for name in packages_to_check {
+        match get_pkg_version(&name) {
             Ok(latest_ver) => updates.push((name.clone(), latest_ver)),
             Err(e) => {
                 eprint(format!("Could not find latest version of {}: {}", name, e));

--- a/src/project_managers.rs
+++ b/src/project_managers.rs
@@ -34,7 +34,7 @@ pub enum Action {
     /// Show the project.toml file
     Info,
     /// Update all packages
-    Update,
+    Update(UpdatePackage),
     /// Build the project
     Build(BuildProject),
     /// Bump project version (major, minor, patch)
@@ -702,6 +702,18 @@ impl BumpVersion {
                 eprint(format!("Failed to update project.toml: {}", e));
             }
         }
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct UpdatePackage {
+    /// List of packages to update
+    pub pkg_names: Vec<String>,
+}
+
+impl UpdatePackage {
+    pub fn update_package(&self) {
+        crate::ppm_functions::update_packages(&self.pkg_names);
     }
 }
 


### PR DESCRIPTION

#44

**Description:**

Updated the update command to accept an optional list of package names as arguments.
Modified the Action::Update enum variant in src/project_managers.rs to store the list of packages.
Refactored the update_packages function in src/ppm_functions.rs to filter and update only the specified packages.
Added validation logic to warn users if a specified package is not found in project.toml.
Preserved the original behavior where running the command without arguments updates all packages in the project.