### PR TITLE
Create autolabler workflow for issues and PRs

### DIFF
--- a/.github/workflows/autolabler.yml
+++ b/.github/workflows/autolabler.yml
@@ -1,0 +1,45 @@
+name: Auto Label Issues and PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add labels to PR
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: prNumber,
+              labels: ["OSCG 2026"]
+            });
+
+            console.log(`Added labels [OSCG 2026] to PR #${prNumber}`);
+
+      - name: Add labels to Issue
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: issueNumber,
+              labels: ["OSCG 2026"]
+            });
+
+            console.log(`Added labels [OSCG 2026] to Issue #${issueNumber}`);


### PR DESCRIPTION
This workflow automatically adds the label 'OSCG 2026' to newly opened pull requests and issues.

Closes #62 

@Sumangal44 