### PR TITLE
docs: replace deprecated pip search with PyPI URL in troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ cargo watch -x build
 
 **Solutions:**
 1. Check package name spelling
-2. Verify package exists: `pip search <package>`
+2. Verify package existence on PyPI: visit `https://pypi.org/project/<package>/` in your browser
 3. Check pip version: `pip --version`
 4. Update pip: `ppmm run upgrade-pip`
 


### PR DESCRIPTION
This PR removes the usage of the deprecated pip search command from the README and replaces it with a modern and reliable alternative using the official PyPI website.

❗ Why this change is needed
pip search has been deprecated and no longer works in recent versions of pip.
Users following the current documentation may encounter errors or confusion.
PyPI web lookup is now the recommended approach for verifying package existence.

🔧 Changes Made

Replaced: pip search <package>
with: https://pypi.org/project/<package>/

Updated troubleshooting guidance to reflect current best practices.

✅ Benefits
Prevents users from running broken commands
Improves documentation accuracy
Aligns with modern Python packaging standards
Reduces support issues related to outdated tooling

🧠 Notes
This change is purely documentation-related and does not affect core functionality of ppmm.